### PR TITLE
更改了提取 twitter 的网址

### DIFF
--- a/P4/src/twitter/Main.java
+++ b/P4/src/twitter/Main.java
@@ -22,7 +22,7 @@ public class Main {
      * within the last hour. This server may take up to a minute to respond, if
      * it has to refresh its cached sample of tweets.
      */
-    public static final URL SAMPLE_SERVER = makeURLAssertWellFormatted("https://github.com/rainywang/Spring2018_HITCS_SC_Lab1/blob/master/P4/src/tweetPoll.py");
+    public static final URL SAMPLE_SERVER = makeURLAssertWellFormatted("https://raw.githubusercontent.com/rainywang/Spring2018_HITCS_SC_Lab1/master/P4/src/tweetPoll.py");
     
     private static URL makeURLAssertWellFormatted(String urlString) {
         try {


### PR DESCRIPTION
如果使用之前的网址读取的内容会是这个 py 文件所在网址的 html 而不是这个文件本身. 必须使用 raw 模式打开这个网址, 才可以正常读取